### PR TITLE
Adds support for limiting CPU and RAM per pod

### DIFF
--- a/example/example-zookeeper-cluster.yaml
+++ b/example/example-zookeeper-cluster.yaml
@@ -9,3 +9,5 @@ metadata:
 spec:
   size: 5
   version: "3.5.3-beta"
+  cpu_request: 500m
+  mem_request: 256M

--- a/pkg/apis/zookeeper/v1alpha1/cluster.go
+++ b/pkg/apis/zookeeper/v1alpha1/cluster.go
@@ -102,6 +102,9 @@ type ClusterSpec struct {
 
 	// zookeeper JVM policy
 	JVM *JVMPolicy `json:"jvm,omitempty"`
+
+	RequestCPU string `json:"cpu_request"`
+	RequestMEM string `json:"mem_request"`
 }
 
 // PodPolicy defines the policy to create pod for the zookeeper container.


### PR DESCRIPTION
On some clusters (especially test-clusters) it might be useful to reduce how much CPU each pod reserves, this adds support for setting the `requests: memory` and `requests: cpu` values.

This would resolve issue #1 